### PR TITLE
Allow configuration of battery icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Put into your path, as an example the following would work
 cd [path/where/tidybattery/will/live]
 git clone https://github.com/nalipaz/tidybattery.git
 cd tidybattery
-sudo ln -s `pwd`/tidybattery.py /usr/bin/tidybattery1
+sudo ln -s `pwd`/tidybattery.py /usr/bin/tidybattery
 ```
 Create a config file at `~/.tidybattery`, just run the following to generate a default config file which you could modify if needed:
 ```
@@ -54,3 +54,7 @@ percent = 95
 icon = gnome-power-manager
 percent = 100
 ```
+
+### Starting tidybattery
+
+Just run `tidybattery &`.  You can also put it into your startups so it is automatically running after reboots.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 tidybattery
 ===========
 
-Lightweight GTK tray battery monitor. Python fork of slimebattery.
+Lightweight GTK tray battery monitor. The original project by [decayofmind](https://github.com/decayofmind/tidybattery) is a fork of slimebattery rewritten in Python.  This project is a fork of that with additions of more levels of icon notification and enabling of clicking on the icon to launch a custom command (like the command for the system power manager).
+
+## Setup
+
+Simplest method is to just git clone and be sure you have Python2.  Then run `./tidybattery.py`.  To enable left-click on the icon specify the `-c` or `--command` option when you run the command.  Example:
+```
+./tidybattery.py -c xfce4-power-manager-settings
+```
+It might also be of use to move the `.py` file to `/usr/bin` or symlink it there so that you can call the program without the path.  Add the command to your startups to have the icon available after boot.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Create a config file at `~/.tidybattery`, just run the following to generate a d
 ```
 echo -e "[general]\ncommand = xfce4-power-manager-settings\n\n[empty]\nicon = battery-empty\ncharge_icon = battery-empty-charging\npercent = 0\n\n[caution]\nicon = battery-caution\ncharge_icon = battery-caution-charging\npercent = 10\n\n[low]\nicon = battery-low\ncharge_icon = battery-low-charging\npercent = 20\n\n[fair]\nicon = battery-fair\ncharge_icon = battery-fair-charging\npercent = 45\n\n[good]\nicon = battery-good\ncharge_icon = battery-good-charging\npercent = 70\n\n[full]\nicon = battery-full\ncharge_icon = battery-full-charging\npercent = 95\n\n[full_adapter]\nicon = gnome-power-manager\npercent = 100" > ~/.tidybattery
 ```
-Alternatively, you can copy the config file below and edit as you need:
+Alternatively, you can manually create your config file using the below as your template:
 ```
 [general]
 command = xfce4-power-manager-settings

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ percent = 95
 icon = gnome-power-manager
 percent = 100
 ```
-Edit the above for your needs.  Alternatively, just run:
+Edit the above for your needs.  Alternatively, just run the following to generated a default config file:
 ```
 echo -e "[general]\ncommand = xfce4-power-manager-settings\n\n[empty]\nicon = battery-empty\ncharge_icon = battery-empty-charging\npercent = 0\n\n[caution]\nicon = battery-caution\ncharge_icon = battery-caution-charging\npercent = 10\n\n[low]\nicon = battery-low\ncharge_icon = battery-low-charging\npercent = 20\n\n[fair]\nicon = battery-fair\ncharge_icon = battery-fair-charging\npercent = 45\n\n[good]\nicon = battery-good\ncharge_icon = battery-good-charging\npercent = 70\n\n[full]\nicon = battery-full\ncharge_icon = battery-full-charging\npercent = 95\n\n[full_adapter]\nicon = gnome-power-manager\npercent = 100" > ~/.tidybattery
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ git clone https://github.com/nalipaz/tidybattery.git
 cd tidybattery
 sudo ln -s `pwd`/tidybattery.py /usr/bin/tidybattery1
 ```
-Create a config file at `~/.tidybattery`, here is a default one you could use:
+Create a config file at `~/.tidybattery`, just run the following to generate a default config file which you could modify if needed:
+```
+echo -e "[general]\ncommand = xfce4-power-manager-settings\n\n[empty]\nicon = battery-empty\ncharge_icon = battery-empty-charging\npercent = 0\n\n[caution]\nicon = battery-caution\ncharge_icon = battery-caution-charging\npercent = 10\n\n[low]\nicon = battery-low\ncharge_icon = battery-low-charging\npercent = 20\n\n[fair]\nicon = battery-fair\ncharge_icon = battery-fair-charging\npercent = 45\n\n[good]\nicon = battery-good\ncharge_icon = battery-good-charging\npercent = 70\n\n[full]\nicon = battery-full\ncharge_icon = battery-full-charging\npercent = 95\n\n[full_adapter]\nicon = gnome-power-manager\npercent = 100" > ~/.tidybattery
+```
+Alternatively, you can copy the config file below and edit as you need:
 ```
 [general]
 command = xfce4-power-manager-settings
@@ -49,8 +53,4 @@ percent = 95
 [full_adapter]
 icon = gnome-power-manager
 percent = 100
-```
-Edit the above for your needs.  Alternatively, just run the following to generated a default config file:
-```
-echo -e "[general]\ncommand = xfce4-power-manager-settings\n\n[empty]\nicon = battery-empty\ncharge_icon = battery-empty-charging\npercent = 0\n\n[caution]\nicon = battery-caution\ncharge_icon = battery-caution-charging\npercent = 10\n\n[low]\nicon = battery-low\ncharge_icon = battery-low-charging\npercent = 20\n\n[fair]\nicon = battery-fair\ncharge_icon = battery-fair-charging\npercent = 45\n\n[good]\nicon = battery-good\ncharge_icon = battery-good-charging\npercent = 70\n\n[full]\nicon = battery-full\ncharge_icon = battery-full-charging\npercent = 95\n\n[full_adapter]\nicon = gnome-power-manager\npercent = 100" > ~/.tidybattery
 ```

--- a/README.md
+++ b/README.md
@@ -4,9 +4,53 @@ tidybattery
 Lightweight GTK tray battery monitor. The original project by [decayofmind](https://github.com/decayofmind/tidybattery) is a fork of [slimebattery](https://github.com/Enrix835/slimebattery) rewritten in Python.  This project is a fork of that with additions of more levels of icon notification and enabling of clicking on the icon to launch a custom command (like the command for the system power manager).
 
 ## Setup
+Put into your path, as an example the following would work
+```
+cd [path/where/tidybattery/will/live]
+git clone https://github.com/nalipaz/tidybattery.git
+cd tidybattery
+sudo ln -s `pwd`/tidybattery.py /usr/bin/tidybattery1
+```
+Create a config file at `~/.tidybattery`, here is a default one you could use:
+```
+[general]
+command = xfce4-power-manager-settings
 
-Simplest method is to just git clone and be sure you have Python2.  Then run `./tidybattery.py`.  To enable left-click on the icon specify the `-c` or `--command` option when you run the command.  Example:
+[empty]
+icon = battery-empty
+charge_icon = battery-empty-charging
+percent = 0
+
+[caution]
+icon = battery-caution
+charge_icon = battery-caution-charging
+percent = 10
+
+[low]
+icon = battery-low
+charge_icon = battery-low-charging
+percent = 20
+
+[fair]
+icon = battery-fair
+charge_icon = battery-fair-charging
+percent = 45
+
+[good]
+icon = battery-good
+charge_icon = battery-good-charging
+percent = 70
+
+[full]
+icon = battery-full
+charge_icon = battery-full-charging
+percent = 95
+
+[full_adapter]
+icon = gnome-power-manager
+percent = 100
 ```
-./tidybattery.py -c xfce4-power-manager-settings
+Edit the above for your needs.  Alternatively, just run:
 ```
-It might also be of use to move the `.py` file to `/usr/bin` or symlink it there so that you can call the program without the path.  Add the command to your startups to have the icon available after boot.
+echo -e "[general]\ncommand = xfce4-power-manager-settings\n\n[empty]\nicon = battery-empty\ncharge_icon = battery-empty-charging\npercent = 0\n\n[caution]\nicon = battery-caution\ncharge_icon = battery-caution-charging\npercent = 10\n\n[low]\nicon = battery-low\ncharge_icon = battery-low-charging\npercent = 20\n\n[fair]\nicon = battery-fair\ncharge_icon = battery-fair-charging\npercent = 45\n\n[good]\nicon = battery-good\ncharge_icon = battery-good-charging\npercent = 70\n\n[full]\nicon = battery-full\ncharge_icon = battery-full-charging\npercent = 95\n\n[full_adapter]\nicon = gnome-power-manager\npercent = 100" > ~/.tidybattery
+```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 tidybattery
 ===========
 
-Lightweight GTK tray battery monitor. The original project by [decayofmind](https://github.com/decayofmind/tidybattery) is a fork of slimebattery rewritten in Python.  This project is a fork of that with additions of more levels of icon notification and enabling of clicking on the icon to launch a custom command (like the command for the system power manager).
+Lightweight GTK tray battery monitor. The original project by [decayofmind](https://github.com/decayofmind/tidybattery) is a fork of [slimebattery](https://github.com/Enrix835/slimebattery) rewritten in Python.  This project is a fork of that with additions of more levels of icon notification and enabling of clicking on the icon to launch a custom command (like the command for the system power manager).
 
 ## Setup
 

--- a/tidybattery.py
+++ b/tidybattery.py
@@ -20,62 +20,91 @@
 import gtk
 import gobject
 import subprocess
+import os
+import ConfigParser
 
 ACPI_CMD = 'acpi'
 TIMEOUT = 2
+config = False
+config_path = os.path.expanduser('~/.tidybattery')
 
-class MainApp:
+try:
+    with open(config_path) as f:
+        config = ConfigParser.SafeConfigParser({'command': None, 'icon': 'battery-full', 'charge_icon': 'battery-full-charging', 'percent': 100})
+        config.read(config_path)
+        b = {}
+        for key in config._sections:
+            if key in ('empty', 'caution', 'low', 'fair', 'good', 'full'):
+                b[key] = config._sections[key]
+                b[key]['percent'] = int(b[key]['percent'])
+except IOError:
+    print 'There must be a config file (~/.tidybattery) setup.  See the README.md for documentation.'
+    exit
+
+if config:
+    class MainApp:
         def __init__(self):
-                self.icon = gtk.StatusIcon()
-                self.update_icon()
-                gobject.timeout_add_seconds(TIMEOUT,self.update_icon)
+            self.last_icon = {}
+            self.icon = gtk.StatusIcon()
+            self.icon.set_from_stock(gtk.STOCK_HOME)
+            self.icon.connect('activate', self.left_click)
+            self.update_icon()
+            gobject.timeout_add_seconds(TIMEOUT,self.update_icon)
+
+        def left_click(self, icon):
+            if config._sections['general']['command'] != None:
+                os.system(config._sections['general']['command'])
+            else:
+                notify = 'notify-send -i "battery" -t 10000 "{title}" "{description}"'
+                os.system(notify.format(title='Command not specified', description='To be able to left click on the status icon, you must specify a command to run on left click of the icon using the \`-c\` flag or the \`--command\` option.  Try \`--help\` for more information.'))
 
         def get_battery_info(self):
-                text = subprocess.check_output(ACPI_CMD).strip('\n')
-                if not 'Battery' in text:
-                        return {'state':"Unknown",
-                                'percentage':0,
-                                'tooltip':""
-                                }
-                data = text.split(',')
-                return {'state':data[0].split(':')[1].strip(' '),
-                                'percentage':int(data[1].strip(' %')),
-                                'tooltip': text.split(':',1)[1][1:]
-                                }
+            text = subprocess.check_output(ACPI_CMD).strip('\n')
+            if not 'Battery' in text:
+                return {
+                    'state': "Unknown",
+                    'percentage': 0,
+                    'tooltip': ""
+                }
+            data = text.split(',')
+            state = data[0].split(':')[1].strip(' ')
+            percentage_str = data[1].strip(' %')
+            percentage = int(percentage_str)
+            time = '' if state in ('Full', 'Unknown') else data[2].split(' ')[1]
+            tooltip = 'Battery is {state}' if state in ('Full', 'Unknown') else 'Battery is {state} ({percentage}%)\n {time} remaining'
+            return {
+                'state': state,
+                'percentage': percentage,
+                'tooltip': tooltip.format(state=state, percentage=percentage, time=time),
+                'time': time,
+            }
 
-        def get_icon_name(self, state, percentage):
-                if state == 'Discharging':
-                        if percentage < 10:
-                                return 'battery_empty'
-                        elif percentage < 20:
-                                return 'battery_caution'
-                        elif percentage < 40:
-                                return 'battery_low'
-                        elif percentage < 60:
-                                return 'battery_two_thirds'
-                        elif percentage < 75:
-                                return 'battery_third_fouth'
-                        else:
-                                return 'battery_full'
-                elif state == 'Charged':
-                        return 'battery_charged'
-                elif state == 'Unknown':
-                        return 'dialog-question'
-                else:
-                        return 'battery_plugged'
+        def get_icon(self, state, percentage):
+            icon = b['full']
+            icon['state'] = 'icon'
+            if state == 'Full':
+                icon = config._sections['full_adapter']
+                icon['state'] = 'icon'
+                return icon
+            closest_match = 0
+            for key in b:
+                if percentage >= b[key]['percent'] and b[key]['percent'] > closest_match:
+                    closest_match = b[key]['percent']
+                    icon = b[key]
+                    icon['state'] = 'icon' if state == 'Discharging' else 'charge_icon'
+            return icon
 
         def update_icon(self):
-                info = self.get_battery_info()
-                icon_name = self.get_icon_name(info['state'],info['percentage'])
-                self.icon.set_from_icon_name(icon_name)
-                self.icon.set_tooltip_text(info['tooltip'])
-                return True
-
-if __name__ == "__main__":
+            info = self.get_battery_info()
+            icon = self.get_icon(info['state'],info['percentage'])
+            self.icon.set_from_icon_name(icon[icon['state']])
+            self.icon.set_tooltip_text(info['tooltip'])
+            return True
+      
+    if __name__ == "__main__":
         try:
-                MainApp()
-                gtk.main()
+            MainApp()
+            gtk.main()
         except KeyboardInterrupt:
-                pass
-
+            pass
 


### PR DESCRIPTION
Here is a PR that does:
- Rewrites some logic surrounding the cases for icons
- Cleans up some whitespace
- Stores details about percentage thresh-holds and battery icon in an external config file.
- Makes a configurable left click available, configurable from config file
